### PR TITLE
Continue the job even if linters fail.

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -65,6 +65,7 @@ jobs:
         [ ! -s "py_test_files.txt" ] || cat py_test_files.txt | xargs -I {} python {}
 
     - name: Lint with protolint
+      continue-on-error: true
       env:
         PROTOLINT_VERSION: 0.25.1
       shell: bash
@@ -77,6 +78,7 @@ jobs:
         [ ! -s "proto_files.txt" ] || cat proto_files.txt | xargs -I {} ./protolint {}
 
     - name: Lint with pylint
+      continue-on-error: true
       shell: bash
       run: |
         pip install pylint


### PR DESCRIPTION
Current linter has many false positives and it seems not justify blocking PRs.
We will proceed to next steps and make the entire job as a success if the linter fails.

Reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error

Please see also https://github.com/tensorflow/tfx/issues/4434